### PR TITLE
Some trie builder utils

### DIFF
--- a/pkg/trie_builder_utils/util.go
+++ b/pkg/trie_builder_utils/util.go
@@ -1,0 +1,90 @@
+package trie_builder_utils
+
+import (
+	"bytes"
+	"math/big"
+
+	"github.com/ethereum/backup/go-ethereum/common"
+	"github.com/ethereum/backup/go-ethereum/trie"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// BuildAndReportKeySetWithBranchToDepth takes a depth argument
+// and returns the first two slots (that when hashed into trie keys) that intersect at or below that provided depth
+// it hashes the slots and converts to nibbles before finding the intersection
+// it also returns the nibble and hex string representations of the two intersecting keys
+// this is useful for identifying what contract slots need to be occupied to cause branching in the storage trie
+// at or below a provided height
+func BuildAndReportKeySetWithBranchToDepth(depth int) (string, string, []byte, []byte, string, string) {
+	slots, storageLeafKeys, storageLeafKeyStrs, key1, key2 := BuildKeySetWithBranchToDepth(depth)
+	var slot1 string
+	var slot2 string
+	var key1Str string
+	var key2Str string
+	for i, storageLeafKey := range storageLeafKeys {
+		if bytes.Equal(storageLeafKey, key1) {
+			slot1 = slots[i]
+			key1Str = storageLeafKeyStrs[i]
+		}
+		if bytes.Equal(storageLeafKey, key2) {
+			slot2 = slots[i]
+			key2Str = storageLeafKeyStrs[i]
+		}
+	}
+	return slot1, slot2, key1, key2, key1Str, key2Str
+}
+
+func BuildKeySetWithBranchToDepth(depth int) ([]string, [][]byte, []string, []byte, []byte) {
+	slots := make([]string, 0)
+	storageLeafKeys := make([][]byte, 0)
+	storageLeafKeyStrs := make([]string, 0)
+	i := 0
+	for {
+		slots = append(slots, common.BigToHash(big.NewInt(int64(i))).String())
+		storageLeafKeys = append(storageLeafKeys, trie.CompactToHex(crypto.Keccak256(common.BigToHash(big.NewInt(int64(i))).Bytes())))
+		storageLeafKeyStrs = append(storageLeafKeyStrs, crypto.Keccak256Hash(common.BigToHash(big.NewInt(int64(i))).Bytes()).String())
+		i++
+		if len(storageLeafKeys) > 1 {
+			d, key1, key2 := checkBranchDepthOfSet(storageLeafKeys)
+			if d >= depth {
+				return slots, storageLeafKeys, storageLeafKeyStrs, key1, key2
+			}
+		}
+	}
+}
+
+func checkBranchDepthOfSet(storageLeafKeys [][]byte) (int, []byte, []byte) {
+	var deepestBranch int
+	var intersectingKey1 []byte
+	var intersectingKey2 []byte
+	for i, key1 := range storageLeafKeys {
+		for j, key2 := range storageLeafKeys {
+			if i == j {
+				continue
+			}
+			var ok bool
+			var growingPrefix []byte
+			for _, by := range key1 {
+				ok, growingPrefix = containsPrefix(key2, growingPrefix, []byte{by})
+				if ok {
+					if len(growingPrefix) > deepestBranch {
+						intersectingKey1 = key1
+						intersectingKey2 = key2
+						deepestBranch = len(growingPrefix)
+					}
+					continue
+				} else {
+					break
+				}
+			}
+		}
+	}
+	return deepestBranch, intersectingKey1, intersectingKey2
+}
+
+func containsPrefix(key, growingPrefix, potentialAddition []byte) (bool, []byte) {
+	if bytes.HasPrefix(key, potentialAddition) {
+		return true, append(growingPrefix, potentialAddition...)
+	}
+	return false, growingPrefix
+}


### PR DESCRIPTION
Useful for https://github.com/cerc-io/go-ethereum/issues/338

Provide a desired branch depth, and these functions will generate and iterate storage slots until they find two storage slots whose corresponding storage keys (nibble representation of the keccak256 hash of the storage slot) intersect at or below that depth. 

For example, for the above issue we can specify a depth of 4 and then populate the two returned slots with a 1 byte value and we should induce a branch node with an internalized leaf node.